### PR TITLE
[AI4EUEXP-40] Delete model not possible for dockerized-uri models

### DIFF
--- a/acumos-portal-be/pom.xml
+++ b/acumos-portal-be/pom.xml
@@ -24,7 +24,7 @@ limitations under the License.
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.acumos.portal-marketplace</groupId>
 	<artifactId>acumos-portal-be</artifactId>
-	<version>4.0.14-ai4eu-v3</version>
+	<version>4.0.14-ai4eu-v4</version>
 	<name>Acumos Portal backend server</name>
 	<description>Acumos Portal Backend APIs</description>
 	<parent>

--- a/acumos-portal-be/src/main/java/org/acumos/portal/be/service/impl/MarketPlaceCatalogServiceImpl.java
+++ b/acumos-portal-be/src/main/java/org/acumos/portal/be/service/impl/MarketPlaceCatalogServiceImpl.java
@@ -351,16 +351,18 @@ public class MarketPlaceCatalogServiceImpl extends AbstractServiceImpl implement
 
 					for (MLPArtifact mlp : mlpArtifactsList) {
 						boolean deleteNexus = false;
-						// Delete the file from the Nexus
 						log.info("mlp.getUri ----->>" + mlp.getUri());
 						log.info("mlp.getArtifactTypeCode ----->>" + mlp.getArtifactTypeCode());
 						
 						try {
 							if ("DI".equals(mlp.getArtifactTypeCode())) {
-								DockerClient dockerClient = DockerClientFactory.getDockerClient(dockerConfiguration);
-								DeleteImageCommand deleteImg = new DeleteImageCommand(mlp.getUri());
-								deleteImg.setClient(dockerClient);
-								deleteImg.execute();
+								String ownDockerRegistryPrefix = env.getProperty("docker.imagetag.prefix");
+								if (mlp.getUri().startsWith(ownDockerRegistryPrefix)) {
+									DockerClient dockerClient = DockerClientFactory.getDockerClient(dockerConfiguration);
+									DeleteImageCommand deleteImg = new DeleteImageCommand(mlp.getUri());
+									deleteImg.setClient(dockerClient);
+									deleteImg.execute();
+								}
 								deleteNexus = true;
 							} else {
 								// Delete the file from the Nexus

--- a/acumos-portal-fe/pom.xml
+++ b/acumos-portal-fe/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.acumos.portal-marketplace</groupId>
 	<artifactId>acumos-portal-fe</artifactId>
-	<version>4.0.14-ai4eu-v3</version>
+	<version>4.0.14-ai4eu-v4</version>
 	<packaging>war</packaging>
 	<name>Acumos Portal frontend server</name>
 	<description>Acumos Portal AngularJS Front End</description>
@@ -31,7 +31,7 @@ limitations under the License.
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.16.RELEASE</version>
+		<version>2.1.1.RELEASE</version>
 		<!-- silence warning about parent relative path -->
 		<relativePath />
 	</parent>
@@ -50,6 +50,7 @@ limitations under the License.
 		<!-- Supplied by Jenkins -->
 		<docker.push.registry>${env.NEXUS3_PUSH_REGISTRY}</docker.push.registry>
 		<sonar.exclusions>**/scripts/**/*,**.js</sonar.exclusions>
+		<mockito.version>1.10.19</mockito.version>
 	</properties>
 	<!-- All dependencies are public, no extra repositories needed. -->
 	<dependencies>
@@ -91,8 +92,8 @@ limitations under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-zuul</artifactId>
-			<version>1.3.1.RELEASE</version>
+			<artifactId>spring-cloud-starter-netflix-zuul</artifactId>
+			<version>2.1.1.RELEASE</version>
 		</dependency>
 			<dependency>
 			<groupId>junit</groupId>

--- a/acumos-portal-fe/src/main/java/org/acumos/portal/fe/ApplicationWebXml.java
+++ b/acumos-portal-fe/src/main/java/org/acumos/portal/fe/ApplicationWebXml.java
@@ -21,7 +21,7 @@
 package org.acumos.portal.fe;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 public class ApplicationWebXml extends SpringBootServletInitializer {
 

--- a/acumos-portal-fe/src/main/java/org/acumos/portal/fe/config/WebConfigurer.java
+++ b/acumos-portal-fe/src/main/java/org/acumos/portal/fe/config/WebConfigurer.java
@@ -29,20 +29,20 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
-import org.springframework.boot.context.embedded.MimeMappings;
+import org.springframework.boot.web.server.MimeMappings;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 
 @EnableAutoConfiguration
-public class WebConfigurer implements ServletContextInitializer, EmbeddedServletContainerCustomizer {
+public class WebConfigurer implements ServletContextInitializer, WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> {
 
 	public WebConfigurer() {
 		// TODO Auto-generated constructor stub
 	}
 
 	@Override
-	public void customize(ConfigurableEmbeddedServletContainer container) {
+	public void customize(ConfigurableServletWebServerFactory container) {
 		MimeMappings mappings = new MimeMappings(MimeMappings.DEFAULT);
         mappings.add("html", "text/html;charset=utf-8");
         mappings.add("json", "text/html;charset=utf-8");
@@ -53,7 +53,7 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
 
 	}
 	
-	private void setLocationForStaticAssets(ConfigurableEmbeddedServletContainer container) {
+	private void setLocationForStaticAssets(ConfigurableServletWebServerFactory container) {
         File root;
         String prefixPath = resolvePathPrefix();
         root = new File(prefixPath + "src/main/webapp/");
@@ -77,5 +77,4 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
 	public void onStartup(ServletContext servletContext) throws ServletException {
 		EnumSet<DispatcherType> disps = EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.ASYNC);
 	}
-
 }

--- a/acumos-portal-fe/src/test/java/org/acumos/fe/test/config/WebConfigurerTest.java
+++ b/acumos-portal-fe/src/test/java/org/acumos/fe/test/config/WebConfigurerTest.java
@@ -29,8 +29,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.embedded.AbstractConfigurableEmbeddedServletContainer;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+//import org.springframework.boot.context.embedded.AbstractConfigurableEmbeddedServletContainer;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.boot.web.servlet.server.AbstractServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 
 
 public class WebConfigurerTest {
@@ -38,8 +42,8 @@ public class WebConfigurerTest {
 	 private static final int _DEFAULT_PORT = 8080;
 
 	 private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-	
-	 private AbstractConfigurableEmbeddedServletContainer dummyconfigurableEmbeddedServletContainer = new AbstractConfigurableEmbeddedServletContainer() {
+
+	 private AbstractServletWebServerFactory dummyconfigurableEmbeddedServletContainer = new AbstractServletWebServerFactory() {
 		 
 		private File root;
 		
@@ -66,6 +70,12 @@ public class WebConfigurerTest {
 		@Override
 		public File getDocumentRoot() {
 			return root;	
+		}
+
+		@Override
+		public WebServer getWebServer(ServletContextInitializer... initializers) {
+			// TODO Auto-generated method stub
+			return null;
 		}		
 	};		
 	

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.acumos.portal-marketplace</groupId>
 	<artifactId>portal-marketplace-parent</artifactId>
-	<version>4.0.14-ai4eu-v3</version>
+	<version>4.0.14-ai4eu-v4</version>
 	<packaging>pom</packaging>
 	<name>Acumos Portal Marketplace parent project</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 	<modules>
 		<!-- Child modules do NOT name this parent. -->


### PR DESCRIPTION
This pull request adds an additional check whether a docker image (artifact type DI) can actually be deleted by Acumos.

If the image is not in the own registry, no deletion attempt is made.


TODO
- [X] Test deletion of models with external images
- [ ] Test deletion of models with images in the own registry